### PR TITLE
Fix build/tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-marshmallow>=3.11
+marshmallow~=3.11


### PR DESCRIPTION
Avoid Marshmallow breaking changes for now by restricting marshmallow versions to >=3.11, <4.0.

Before this change, pytests failed:
```
Traceback:
/usr/lib/python3.11/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/__init__.py:4: in <module>
    from marshmallow_jsonschema import JSONSchema
marshmallow_jsonschema/__init__.py:6: in <module>
    from .base import JSONSchema
marshmallow_jsonschema/base.py:11: in <module>
    from marshmallow.utils import _Missing
E   ImportError: cannot import name '_Missing' from 'marshmallow.utils'
```

Now, they pass:
`64 passed, 365 warnings in 0.45s`