### PR TITLE
Add Support for `marshmallow.fields.Enum` in marshmallow ≥ v3.18

### DIFF
--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -19,7 +19,7 @@ def test_import_marshmallow_enum(monkeypatch):
 
     base = importlib.reload(marshmallow_jsonschema.base)
 
-    assert not base.ALLOW_ENUMS
+    assert not base.ALLOW_MARSHMALLOW_ENUM_ENUMS
 
     monkeypatch.undo()
 


### PR DESCRIPTION
This fixes #10. (169 in upstream - PR 170)

Detailed changes:
* Introduce distinction between Enums imports from `marshmallow_enum` and `marshmallow.fields` (the latter are refered to as "marshmallow native" Enums)
* Add function to find out if the version of marshmallow used supports the native Enum type
* Add test cases that reproduce the issue
* Adapt the code to also support the native enums