### PR TITLE
fix(validation): handle_one_of uses oneOf instead of enum

### DIFF
--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -486,8 +486,10 @@ def test_dumps_iterable_enums():
     dumped = validate_and_dump(schema)
 
     assert dumped["definitions"]["TestSchema"]["properties"]["foo"] == {
-        "enum": [v for v in mapping.values()],
-        "enumNames": [k for k in mapping.keys()],
+        "oneOf": [
+            {"type": "number", "title": k, "const": v}
+            for k, v in zip(mapping.keys(), mapping.values())
+        ],
         "format": "integer",
         "title": "foo",
         "type": "number",


### PR DESCRIPTION
This fixes https://github.com/stretch4x4/marshmallow-jsonschema/issues/15. (- in upstream - [PR 95](https://github.com/fuhrysteve/marshmallow-jsonschema/pull/95))

> `enumNames` is not part of the JSON Schema spec, it was part of a draft but was never accepted. It is possible to get the same behaviour using a `oneOf` property with titles