### PR TITLE
Added bugfix for Union causing issues

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -13,8 +13,7 @@ from marshmallow.utils import _Missing
 from marshmallow import INCLUDE, EXCLUDE, RAISE
 
 try:
-    from marshmallow_union import Union
-
+    from marshmallow_dataclass.union_field import Union
     ALLOW_UNIONS = True
 except ImportError:
     ALLOW_UNIONS = False
@@ -241,12 +240,12 @@ class JSONSchema(Schema):
         self, obj, field
     ) -> typing.Dict[str, typing.List[typing.Any]]:
         """Get a union type schema. Uses anyOf to allow the value to be any of the provided sub fields"""
-        assert ALLOW_UNIONS and isinstance(field, Union)
+        assert isinstance(field, Union)
 
         return {
             "anyOf": [
                 self._get_schema_for_field(obj, sub_field)
-                for sub_field in field._candidate_fields
+                for _, sub_field in field.union_fields
             ]
         }
 
@@ -268,7 +267,7 @@ class JSONSchema(Schema):
             if isinstance(field, fields.Nested):
                 # Special treatment for nested fields.
                 schema = self._from_nested_schema(obj, field)
-            elif ALLOW_UNIONS and isinstance(field, Union):
+            elif isinstance(field, Union):
                 schema = self._from_union_schema(obj, field)
             else:
                 pytype = self._get_python_type(field)

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -3,7 +3,7 @@ import marshmallow_jsonschema
 
 
 def test_import_marshmallow_union(monkeypatch):
-    monkeypatch.delattr("marshmallow_union.Union")
+    monkeypatch.delattr("marshmallow_dataclass.union_field.Union")
 
     base = importlib.reload(marshmallow_jsonschema.base)
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -4,7 +4,7 @@ import pytest
 from marshmallow import Schema, fields, validate
 from marshmallow.validate import OneOf, Range
 from marshmallow_enum import EnumField
-from marshmallow_union import Union
+from marshmallow_dataclass.union_field import Union
 
 from marshmallow_jsonschema import JSONSchema, UnsupportedValueError
 from . import UserSchema, validate_and_dump
@@ -190,12 +190,12 @@ def test_enum():
 
 def test_union():
     class TestSchema(Schema):
-        foo = Union([fields.String(), fields.Integer()])
+        foo = Union([(str, fields.String()), (int, fields.Integer())])
 
     schema = TestSchema()
 
     dumped = validate_and_dump(schema)
 
     foo_property = dumped["definitions"]["TestSchema"]["properties"]["foo"]
-    assert {"title": "", "type": "string"} in foo_property["anyOf"]
-    assert {"title": "", "type": "integer"} in foo_property["anyOf"]
+    assert {"title": "foo", "type": "string"} in foo_property["anyOf"]
+    assert {"title": "foo", "type": "integer"} in foo_property["anyOf"]


### PR DESCRIPTION
This PR would currently drop using the Union class in marshmallow_union in favor of the Union class in marshmallow_dataclass.union_field. This allows the following functionality: if you declare a dataclass with a variable which can take in multiple types, e.g.:
`
@dataclass `
`class A: `
`     var: int | str 
`
You can then run it through `marshmallow_dataclass` via `class_schema`, which uses the `Union` type in `marshmallow_dataclass.union_field`. The changes in this code ensure running `JSONSchema().dump` on the resulting dataclass doesn't fail. 