### PR TITLE
Rename to have unique workflow names

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: Mypy
 
 on:
   push:


### PR DESCRIPTION
Noticed two workflows using the same display name `Lint`, one running black and the other running mypy.

Path of least resistance was to rename one, but if you'd prefer to consolidate that might make more sense.

Alternatives:

1. Combine black and mypy into a single `Lint` workflow.
2. Combine black and mypy into the `Test Coverage` workflow.

<img width="777" height="271" alt="screenshot_from_2025_09_09_16_41_22" src="https://github.com/user-attachments/assets/06865148-0417-4fb4-b7f3-05edbf68acd8" />
