### PR TITLE
Update package details for the new fork

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+0.14.0 (2025-mm-dd)
+    - First release of the new fork at stretch4x4/marshmallow-jsonschema
+    - TODO: list other changes
 0.13.0 (2021-10-21)
     - Fixes to field default #151
       - The default value for nested fields wasn't serialized.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Setting Up for Local Development
 
 ::
 
-    $ git clone https://github.com/fuhrysteve/marshmallow-jsonschema.git
+    $ git clone https://github.com/stretch4x4/marshmallow-jsonschema.git
     $ cd marshmallow_jsonschema
 
 2. Create a virtual environment and install all dependencies

--- a/README.md
+++ b/README.md
@@ -1,27 +1,42 @@
-## marshmallow-jsonschema: JSON Schema formatting with marshmallow
+# marshmallow-jsonschema
 
-![Build Status](https://github.com/fuhrysteve/marshmallow-jsonschema/workflows/build/badge.svg)
+> **NOTE**
+>
+> This is a maintained refactor of the original [marshmallow-jsonschema project]
+  (https://github.com/fuhrysteve/marshmallow-jsonschema).
+>
+> The main goals of this refactor were:
+>
+> - Fix some long standing bugs
+> - Support newer versions of Python
+> - Publish a more recent release
+> - Modernise builds and tooling to enable active development and future work
+
+## Overview
+
+![Build Status](https://github.com/stretch4x4/marshmallow-jsonschema/actions/workflows/build.yml/badge.svg)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
 
  marshmallow-jsonschema translates marshmallow schemas into
  JSON Schema Draft v7 compliant jsonschema. See http://json-schema.org/
 
-#### Why would I want my schema translated to JSON?
+### Why would I want my schema translated to JSON?
 
 What are the use cases for this? Let's say you have a
 marshmallow schema in python, but you want to render your
 schema as a form in another system (for example: a web browser
 or mobile device).
 
-#### Installation
+## Installation
 
-Requires python>=3.6 and marshmallow>=3.11. (For python 2 & marshmallow 2 support, please use marshmallow-jsonschema<0.11)
+Requires python>=3.6 and marshmallow>=3.11. (For python 2 & marshmallow 2 support, please use
+marshmallow-jsonschema<0.11)
 
 ```
 pip install marshmallow-jsonschema
 ```
 
-#### Some Client tools can render forms using JSON Schema
+## Some Client tools can render forms using JSON Schema
 
 * [react-jsonschema-form](https://github.com/mozilla-services/react-jsonschema-form) (recommended)
   * See below extension for this excellent library!
@@ -29,9 +44,9 @@ pip install marshmallow-jsonschema
 * https://github.com/jdorn/json-editor
 * https://github.com/ulion/jsonform
 
-### Examples
+## Examples
 
-#### Simple Example
+### Simple Example
 
 ```python
 from marshmallow import Schema, fields
@@ -62,7 +77,7 @@ Yields:
  'type': 'object'}
 ```
 
-#### Nested Example
+### Nested Example
 
 ```python
 from marshmallow import Schema, fields
@@ -88,7 +103,7 @@ athlete_schema = AthleteSchema()
 athlete_schema.dump(athlete)
 ```
 
-#### Complete example Flask application using brutisin/json-forms
+### Complete example Flask application using brutisin/json-forms
 
 ![Screenshot](http://i.imgur.com/jJv1wFk.png)
 
@@ -152,8 +167,8 @@ if __name__ == '__main__':
 ```
 
 
-### Advanced usage
-#### Custom Type support
+## Advanced usage
+### Custom Type support
 
 Simply add a `_jsonschema_type_mapping` method to your field
 so we know how it ought to get serialized to JSON Schema.
@@ -235,3 +250,4 @@ data = json_schema_obj.dump(schema)
 
 # ..and here's your uiSchema!
 ui_schema_json = json_schema_obj.dump_uischema(schema)
+```

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,3 +8,4 @@ marshmallow-union
 mypy>=1.1.1
 
 pre-commit~=2.15
+-e.

--- a/setup.py
+++ b/setup.py
@@ -34,14 +34,14 @@ EXTRAS_REQUIRE = {
 
 setup(
     name="marshmallow-jsonschema",
-    version="0.13.0",
+    version="0.14.0",
     description="JSON Schema Draft v7 (http://json-schema.org/)"
     " formatting with marshmallow",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    author="Stephen Fuhry",
-    author_email="fuhrysteve@gmail.com",
-    url="https://github.com/fuhrysteve/marshmallow-jsonschema",
+    author="Stephen Fuhry, stretch4x4",
+    author_email="stretch4x4@users.noreply.github.com",
+    url="https://github.com/stretch4x4/marshmallow-jsonschema",
     packages=find_packages(exclude=("test*",)),
     package_dir={"marshmallow-jsonschema": "marshmallow-jsonschema"},
     include_package_data=True,


### PR DESCRIPTION
Fixes part of #8 and part of #9.

The build status badge URL was actually broken before, but as I was already updating that line for the new author it was easy to do at the same timesd.

TODO:

- [ ] Setup a release workflow on GHA. The `Makefile` appears to use `twine` but is all executed manually and locally.
- [ ] Build and test on Python 3.6.
- [ ] Compile missing release notes.