### PR TITLE
Fix release workflow by adding a checkout step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - uses: actions/checkout@v5
     - name: Download all the dists
       uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
To fix the below error encountered on previous release:

```
Run gh release create v0.15.0 --title v0.15.0 --generate-notes dist/*
  gh release create v0.15.0 --title v0.15.0 --generate-notes dist/*
  shell: /usr/bin/bash -e {0}
  env:
    GITHUB_TOKEN: ***
failed to run git: fatal: not a git repository (or any of the parent directories): .git

Error: Process completed with exit code 1.
```

Appears the `gh release create` CLI command requires the repo to be checked out.