### PR TITLE
Add ContainsOnly validation support via anyOf

### DIFF
--- a/marshmallow_jsonschema/base.py
+++ b/marshmallow_jsonschema/base.py
@@ -20,6 +20,7 @@ from packaging.version import Version
 
 from .exceptions import UnsupportedValueError
 from .validation import (
+    handle_any_of,
     handle_equal,
     handle_length,
     handle_one_of,
@@ -116,6 +117,7 @@ FIELD_VALIDATORS = {
     validate.Equal: handle_equal,
     validate.Length: handle_length,
     validate.OneOf: handle_one_of,
+    validate.ContainsOnly: handle_any_of,
     validate.Range: handle_range,
     validate.Regexp: handle_regexp,
 }

--- a/marshmallow_jsonschema/validation.py
+++ b/marshmallow_jsonschema/validation.py
@@ -88,6 +88,40 @@ def handle_one_of(schema, field, validator, _parent_schema):
     return schema
 
 
+def handle_any_of(schema, field, validator, _parent_schema):
+    """Adds the validation logic for ``marshmallow.validate.ContainsOnly`` by setting
+    the JSONSchema `anyOf` property to the allowed choices in the validator.
+    Args:
+        schema (dict): The original JSON schema we generated. This is what we
+            want to post-process.
+        field (fields.Field): The field that generated the original schema and
+            who this post-processor belongs to.
+        validator (marshmallow.validate.ContainsOnly): The validator attached to the
+            passed in field.
+        _parent_schema (marshmallow.Schema): The Schema instance that the field
+            belongs to.
+    Returns:
+        dict: New JSON Schema that has been post processed and
+            altered.
+    """
+    if schema["type"] != "array":
+        return schema
+
+    choices = field._serialize(validator.choices, field.name, None)
+    if not choices:
+        return schema
+
+    field_type = schema["items"].get("type", "string")
+
+    labels = validator.labels if validator.labels else choices
+    schema["items"]["anyOf"] = [
+        {"type": field_type, "title": label, "const": choice} for choice, label in zip(choices, labels, strict=False)
+    ]
+    schema["uniqueItems"] = True
+
+    return schema
+
+
 def handle_equal(schema, _field, validator, _parent_schema):
     """Adds the validation logic for ``marshmallow.validate.Equal`` by setting
     the JSONSchema `enum` property to value of the validator.

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,7 +2,7 @@ from enum import Enum
 
 import pytest
 from marshmallow import Schema, fields, validate
-from marshmallow.validate import OneOf, Range
+from marshmallow.validate import ContainsOnly, OneOf, Range
 from marshmallow_enum import EnumField
 from marshmallow_union import Union
 
@@ -98,6 +98,60 @@ def test_one_of_custom_field():
 
     foo_property = dumped["definitions"]["TestSchema"]["properties"]["foo"]
     assert foo_property["oneOf"] == [{"const": "one"}, {"const": "two"}]
+
+
+def test_any_of_validator():
+    class TestSchema(Schema):
+        foo = fields.List(
+            fields.String,
+            validate=ContainsOnly(choices=["apple", "lime", "orange"], labels=["Apple", "Lime", "Orange"]),
+        )
+
+    schema = TestSchema()
+
+    dumped = validate_and_dump(schema)
+
+    foo_property = dumped["definitions"]["TestSchema"]["properties"]["foo"]
+    assert foo_property["uniqueItems"] is True
+    assert foo_property["items"]["anyOf"] == [
+        {"type": "string", "title": "Apple", "const": "apple"},
+        {"type": "string", "title": "Lime", "const": "lime"},
+        {"type": "string", "title": "Orange", "const": "orange"},
+    ]
+
+
+def test_any_of_validator_empty_choice():
+    class TestSchema(Schema):
+        foo = fields.List(
+            fields.String,
+            validate=ContainsOnly(choices=[]),
+        )
+
+    schema = TestSchema()
+
+    dumped = validate_and_dump(schema)
+
+    foo_property = dumped["definitions"]["TestSchema"]["properties"]["foo"]
+    assert foo_property == {
+        "title": "foo",
+        "type": "array",
+        "items": {"title": "foo", "type": "string"},
+    }
+
+
+def test_any_of_validator_with_string_field():
+    class TestSchema(Schema):
+        foo = fields.String(
+            validate=ContainsOnly(choices=["apple", "lime", "orange"], labels=["Apple", "Lime", "Orange"])
+        )
+
+    schema = TestSchema()
+
+    dumped = validate_and_dump(schema)
+
+    foo_property = dumped["definitions"]["TestSchema"]["properties"]["foo"]
+    assert "uniqueItems" not in foo_property
+    assert "items" not in foo_property
 
 
 def test_range():


### PR DESCRIPTION
Fixes #17 replaces #18 

Main change by @jgroth

This field validation wasn't supported but has now been added and results in `anyOf` in the jsonschema