### PR TITLE
Fix code format badge after tooling change

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@
 <!--- TODO: re-enable the following badge once we split coverage and testing - put after testing --->
 <!--- ![Coverage]&#40;https://github.com/stretch4x4/marshmallow-jsonschema/actions/workflows/pytest_and_coverage.yml/badge.svg&#41;) --->
 ![Build Status](https://github.com/stretch4x4/marshmallow-jsonschema/actions/workflows/pytest_and_coverage.yml/badge.svg)
-[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![CodeQL](https://github.com/stretch4x4/marshmallow-jsonschema/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/stretch4x4/marshmallow-jsonschema/actions/workflows/codeql-analysis.yml)
 [![OSSAR](https://github.com/stretch4x4/marshmallow-jsonschema/actions/workflows/ossar-analysis.yml/badge.svg)](https://github.com/stretch4x4/marshmallow-jsonschema/actions/workflows/ossar-analysis.yml)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 ![PyPI - Version](https://img.shields.io/pypi/v/marshmallow-jsonschema)
 ![GitHub Release](https://img.shields.io/github/v/release/stretch4x4/marshmallow-jsonschema)
 


### PR DESCRIPTION
Black has been replaced with ruff format.
And linting is now done with ruff also.

This resulted in the black badge being broken, so updating to a ruff badge.