### PR TITLE
Integrate bump-my-version and towncrier into release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,11 +78,6 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         branch: ${{ github.ref }}
         tags: true
-    - name: Store the release notes
-      uses: actions/upload-artifact@v4
-      with:
-        name: release_notes
-        path: ReleaseNotes.rst
 
   build:
     name: Build distribution 📦
@@ -116,16 +111,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
+      with:
+        ref: ${{needs.bump_version_and_notes.outputs.release_tag}}
     - name: Download all the dists
       uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
-    - name: Download the release notes
-      uses: actions/download-artifact@v4
-      with:
-        name: release_notes
-        path: ReleaseNotes.rst
     - name: Create GitHub Release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -164,6 +156,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
+      with:
+        ref: ${{needs.bump_version_and_notes.outputs.release_tag}}
     - run: |
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,9 @@ jobs:
     - bump_version_and_notes
     runs-on: ubuntu-latest
 
+    steps:
+    - run: echo The release version tag is ${{needs.bump_version_and_notes.outputs.release_tag}}
+
   build:
     name: Build distribution 📦
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,14 @@ jobs:
         branch: ${{ github.ref }}
         tags: true
 
+  # This is a no-op job that simply displays the release version tag at a glance in the UI.
+  # Unfortunately GHA doesn't yet support updating the run name based on job outputs
+  display_version:
+    name: ${{needs.bump_version_and_notes.outputs.release_tag}}
+    needs:
+    - bump_version_and_notes
+    runs-on: ubuntu-latest
+
   build:
     name: Build distribution 📦
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,39 +1,103 @@
-# This workflow is mostly copied from the official PyPA guide:
-# https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
-#
-# Note: There are improvements that could be made to streamline the release process further such as integrating helpers
-#       like bump-my-version and towncrier
-#
 # Instructions:
 #
-# 1. Finalise development on the master branch
-# 2. Update the version number in pyproject.toml appropriately
-# 3. Commit `git commit -m "vx.x.x release"`
-# 4. Tag `git tag vx.x.x`
-# 5. Push `git push && git push --tags`
-# 6. This workflow will automatically be triggered in GitHub Actions based on the new tag
-# 7. Update the version number in pyproject.toml again to a development version e.g. v1.2.3.dev0
-# 8. Commit `git commit -m "Update version number between releases"`
-# 9. Push `git push`
-name: Publish Python 🐍 distribution 📦 to GitHub Releases and PyPI
+# 1. Finalise development on the master branch (merge all desired PRs etc)
+# 2. Navigate to the GitHub Actions UI and select the Release workflow
+#    https://github.com/kyluca/marshmallow-jsonschema/actions/workflows/release.yml
+# 3. Select "Run workflow"
+#
+# TODO: Support pre-releases and alpha/beta deployments from branches other than master
+name: Release 🚀
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
+  workflow_dispatch:
+
+env:
+  BUMPVERSION_VERSION: "1.2.3"
+  PYTHON_VERSION: "3.10"
+  TOWNCRIER_VERSION: "25.8.0"
+  UV_VERSION: "0.8.18"
 
 jobs:
-  build:
-    name: Build distribution 📦
+  bump_version_and_notes:
+    name: Finalise the release notes and bump the version
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required to push back to the repo
+    outputs:
+      release_version: ${{ steps.release_notes.outputs.release_version }}
 
     steps:
     - uses: actions/checkout@v5
     - name: Set up Python
       uses: astral-sh/setup-uv@v6
       with:
-        version: "0.8.18"
-        python-version: "3.10"
+        version: ${{ env.UV_VERSION }}
+        python-version: ${{ env.PYTHON_VERSION }}
+    - name: Validate initial version
+      shell: bash
+      run: |
+        # Validate that we're starting the process from a dev version, otherwise fail the workflow
+        current_version=`uvx bump-my-version@${{ env.BUMPVERSION_VERSION }} show current_version 2>/dev/null`
+        if [[ ${current_version} != *".dev"* ]]; then
+          echo "Non-dev version detected, please verify repo state manually: ${current_version}"
+          exit 1
+        fi
+    - name: Determine the semantic version bump type required
+      id: determine_bump
+      shell: bash
+      run: |
+        breaking=`ls -1 unreleased_notes/*.breaking 2>/dev/null | wc -l`
+        feature=`ls -1 unreleased_notes/*.feature 2>/dev/null | wc -l`
+        if [ ${breaking} != 0 ]; then
+          bump_type="major"
+        elif [ ${feature} != 0 ]; then
+          bump_type="minor"
+        else
+          bump_type="patch"
+        fi
+        echo "bump_type=${bump_type}" >> $GITHUB_OUTPUT
+    - name: Bump to prepare the new version
+      # e.g. 1.2.3.dev0
+      id: prebump
+      # Only perform a major or minor bump, as the patch version should already be bumped after the previous release
+      if: contains(fromJSON('["major", "minor"]'), steps.determine_bump.outputs.bump_type)
+      run: uvx bump-my-version@${{ env.BUMPVERSION_VERSION }} bump ${{ steps.determine_bump.outputs.bump_type }}
+    - name: Finalise release notes
+      id: release_notes
+      run: |
+        release_version=`uvx bump-my-version@${{ env.BUMPVERSION_VERSION }} show-bump --ascii | grep release | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" 2>/dev/null`
+        uvx towncrier@${{ env.TOWNCRIER_VERSION }} --yes --version ${release_version}
+        echo "release_version=${release_version}" >> $GITHUB_OUTPUT
+    - name: Bump to the release version
+      # e.g. 1.2.3
+      run: uvx bump-my-version@${{ env.BUMPVERSION_VERSION }} bump --allow-dirty --commit --tag release
+    - name: Push changes
+      uses: ad-m/github-push-action@v1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: ${{ github.ref }}
+        tags: true
+    - name: Store the release notes
+      uses: actions/upload-artifact@v4
+      with:
+        name: release_notes
+        path: ReleaseNotes.rst
+
+  build:
+    name: Build distribution 📦
+    needs:
+    - bump_version_and_notes
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        ref: ${{needs.bump_version_and_notes.outputs.release_version}}
+    - name: Set up Python
+      uses: astral-sh/setup-uv@v6
+      with:
+        version: ${{ env.UV_VERSION }}
+        python-version: ${{ env.PYTHON_VERSION }}
     - name: Build a binary wheel and a source tarball
       run: uv build
     - name: Store the distribution packages
@@ -45,6 +109,7 @@ jobs:
   publish-to-gh:
     name: Publish GitHub release 📖
     needs:
+    - bump_version_and_notes
     - build
     runs-on: ubuntu-latest
 
@@ -55,10 +120,15 @@ jobs:
       with:
         name: python-package-distributions
         path: dist/
+    - name: Download the release notes
+      uses: actions/download-artifact@v4
+      with:
+        name: release_notes
+        path: ReleaseNotes.rst
     - name: Create GitHub Release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: gh release create ${{ github.ref_name }} --title ${{ github.ref_name }} --generate-notes dist/*
+      run: gh release create ${{needs.bump_version_and_notes.outputs.release_version}} --title ${{needs.bump_version_and_notes.outputs.release_version}} -F ReleaseNotes.rst dist/*
 
   publish-to-pypi:
     # Temporarily disabling this job until we take ownership of the project on PyPI or rename this fork
@@ -69,9 +139,9 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/<package-name>  # Replace <package-name> with your PyPI project name
+      url: https://pypi.org/p/marshmallow-jsonschema
     permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
+      id-token: write  # Required for trusted publishing
 
     steps:
     - name: Download all the dists
@@ -79,5 +149,28 @@ jobs:
       with:
         name: python-package-distributions
         path: dist/
+    # TODO: Can replace the below with `uv publish` once tested
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
+
+  bump_dev_version:
+    name: Bump to the next patch development version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required to push back to the repo
+
+    steps:
+    - uses: actions/checkout@v5
+    - name: Set up Python
+      uses: astral-sh/setup-uv@v6
+      with:
+        version: ${{ env.UV_VERSION }}
+        python-version: ${{ env.PYTHON_VERSION }}
+    - name: Bump to start the next dev version
+      # e.g. 1.2.4.dev0
+      run: uvx bump-my-version@${{ env.BUMPVERSION_VERSION }} bump --allow-dirty --commit patch
+    - name: Push changes
+      uses: ad-m/github-push-action@v1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: ${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       contents: write  # Required to push back to the repo
     outputs:
-      release_version: ${{ steps.release_notes.outputs.release_version }}
+      release_tag: ${{ steps.release_notes.outputs.release_tag }}
 
     steps:
     - uses: actions/checkout@v5
@@ -68,7 +68,7 @@ jobs:
       run: |
         release_version=`uvx bump-my-version@${{ env.BUMPVERSION_VERSION }} show-bump --ascii | grep release | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" 2>/dev/null`
         uvx towncrier@${{ env.TOWNCRIER_VERSION }} --yes --version ${release_version}
-        echo "release_version=${release_version}" >> $GITHUB_OUTPUT
+        echo "release_tag=v${release_version}" >> $GITHUB_OUTPUT
     - name: Bump to the release version
       # e.g. 1.2.3
       run: uvx bump-my-version@${{ env.BUMPVERSION_VERSION }} bump --allow-dirty --commit --tag release
@@ -93,7 +93,7 @@ jobs:
     steps:
     - uses: actions/checkout@v5
       with:
-        ref: ${{needs.bump_version_and_notes.outputs.release_version}}
+        ref: ${{needs.bump_version_and_notes.outputs.release_tag}}
     - name: Set up Python
       uses: astral-sh/setup-uv@v6
       with:
@@ -129,7 +129,7 @@ jobs:
     - name: Create GitHub Release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: gh release create ${{needs.bump_version_and_notes.outputs.release_version}} --title ${{needs.bump_version_and_notes.outputs.release_version}} -F ReleaseNotes.rst dist/*
+      run: gh release create ${{needs.bump_version_and_notes.outputs.release_tag}} --title ${{needs.bump_version_and_notes.outputs.release_tag}} -F ReleaseNotes.rst dist/*
 
   publish-to-pypi:
     # Temporarily disabling this job until we take ownership of the project on PyPI or rename this fork

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,8 +66,12 @@ jobs:
     - name: Finalise release notes
       id: release_notes
       run: |
+        # Extract the release version number
         release_version=`uvx bump-my-version@${{ env.BUMPVERSION_VERSION }} show-bump --ascii | grep release | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" 2>/dev/null`
+        # Generate the new release notes (this command also stages the associated changes)
         uvx towncrier@${{ env.TOWNCRIER_VERSION }} build --yes --version ${release_version}
+        # Extract just the subset of new release notes
+        git diff --cached -U0 ReleaseNotes.rst | grep '^\+' | grep -Ev '^(--- a/|\+\+\+ b/)' | sed 's/\+//g' > notes_subset.rst
         echo "release_tag=v${release_version}" >> $GITHUB_OUTPUT
     - name: Bump to the release version
       # e.g. 1.2.3
@@ -78,6 +82,11 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         branch: ${{ github.ref }}
         tags: true
+    - name: Store the release notes subset
+      uses: actions/upload-artifact@v4
+      with:
+        name: notes_subset
+        path: notes_subset.rst
 
   # This is a no-op job that simply displays the release version tag at a glance in the UI.
   # Unfortunately GHA doesn't yet support updating the run name based on job outputs
@@ -126,10 +135,14 @@ jobs:
       with:
         name: python-package-distributions
         path: dist/
+    - name: Download release notes subset
+      uses: actions/download-artifact@v4
+      with:
+        name: notes_subset
     - name: Create GitHub Release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: gh release create ${{needs.bump_version_and_notes.outputs.release_tag}} --title ${{needs.bump_version_and_notes.outputs.release_tag}} -F ReleaseNotes.rst dist/*
+      run: gh release create ${{needs.bump_version_and_notes.outputs.release_tag}} --title ${{needs.bump_version_and_notes.outputs.release_tag}} -F notes_subset.rst dist/*
 
   publish-to-pypi:
     # Temporarily disabling this job until we take ownership of the project on PyPI or rename this fork

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,6 @@ jobs:
         version: ${{ env.UV_VERSION }}
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Validate initial version
-      shell: bash
       run: |
         # Validate that we're starting the process from a dev version, otherwise fail the workflow
         current_version=`uvx bump-my-version@${{ env.BUMPVERSION_VERSION }} show current_version 2>/dev/null`
@@ -47,26 +46,17 @@ jobs:
         fi
     - name: Determine the semantic version bump type required
       id: determine_bump
-      shell: bash
       run: |
-        echo "Classic debug 1"
         breaking=`ls -1 unreleased_notes/*.breaking 2>/dev/null | wc -l`
-        echo "Classic debug 2"
         feature=`ls -1 unreleased_notes/*.feature 2>/dev/null | wc -l`
-        echo "Classic debug 3"
         if [ $breaking != 0 ]; then
-          echo "Classic debug 4"
           bump_type="major"
         elif [ $feature != 0 ]; then
-          echo "Classic debug 5"
           bump_type="minor"
         else
-          echo "Classic debug 6"
           bump_type="patch"
         fi
-        echo "Classic debug 7"
         echo "bump_type=${bump_type}" >> $GITHUB_OUTPUT
-        echo "Classic debug 8"
     - name: Bump to prepare the new version
       # e.g. 1.2.3.dev0
       id: prebump

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@
 #
 # 1. Finalise development on the master branch (merge all desired PRs etc)
 # 2. Navigate to the GitHub Actions UI and select the Release workflow
-#    https://github.com/kyluca/marshmallow-jsonschema/actions/workflows/release.yml
+#    https://github.com/stretch4x4/marshmallow-jsonschema/actions/workflows/release.yml
 # 3. Select "Run workflow"
 #
 # TODO: Support pre-releases and alpha/beta deployments from branches other than master
@@ -28,6 +28,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
+    - run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
     - name: Set up Python
       uses: astral-sh/setup-uv@v6
       with:
@@ -48,9 +51,9 @@ jobs:
       run: |
         breaking=`ls -1 unreleased_notes/*.breaking 2>/dev/null | wc -l`
         feature=`ls -1 unreleased_notes/*.feature 2>/dev/null | wc -l`
-        if [ ${breaking} != 0 ]; then
+        if [[ "${breaking}" != 0 ]]; then
           bump_type="major"
-        elif [ ${feature} != 0 ]; then
+        elif [[ "${feature}" != 0 ]]; then
           bump_type="minor"
         else
           bump_type="patch"
@@ -155,12 +158,17 @@ jobs:
 
   bump_dev_version:
     name: Bump to the next patch development version
+    needs:
+    - publish-to-gh
     runs-on: ubuntu-latest
     permissions:
       contents: write  # Required to push back to the repo
 
     steps:
     - uses: actions/checkout@v5
+    - run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
     - name: Set up Python
       uses: astral-sh/setup-uv@v6
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,7 @@ jobs:
   bump_dev_version:
     name: Bump to the next patch development version
     needs:
+    - bump_version_and_notes
     - publish-to-gh
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
       id: release_notes
       run: |
         release_version=`uvx bump-my-version@${{ env.BUMPVERSION_VERSION }} show-bump --ascii | grep release | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" 2>/dev/null`
-        uvx towncrier@${{ env.TOWNCRIER_VERSION }} --yes --version ${release_version}
+        uvx towncrier@${{ env.TOWNCRIER_VERSION }} build --yes --version ${release_version}
         echo "release_tag=v${release_version}" >> $GITHUB_OUTPUT
     - name: Bump to the release version
       # e.g. 1.2.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,16 +49,24 @@ jobs:
       id: determine_bump
       shell: bash
       run: |
+        echo "Classic debug 1"
         breaking=`ls -1 unreleased_notes/*.breaking 2>/dev/null | wc -l`
+        echo "Classic debug 2"
         feature=`ls -1 unreleased_notes/*.feature 2>/dev/null | wc -l`
-        if [[ "${breaking}" != 0 ]]; then
+        echo "Classic debug 3"
+        if [ $breaking != 0 ]; then
+          echo "Classic debug 4"
           bump_type="major"
-        elif [[ "${feature}" != 0 ]]; then
+        elif [ $feature != 0 ]; then
+          echo "Classic debug 5"
           bump_type="minor"
         else
+          echo "Classic debug 6"
           bump_type="patch"
         fi
+        echo "Classic debug 7"
         echo "bump_type=${bump_type}" >> $GITHUB_OUTPUT
+        echo "Classic debug 8"
     - name: Bump to prepare the new version
       # e.g. 1.2.3.dev0
       id: prebump

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,28 @@
+# Contributing Guide
+
+## Writing release notes
+
+This repo uses the [towncrier](https://github.com/twisted/towncrier) tool for managing release notes.
+
+When submitting a PR, please include a news fragment file in the [unreleased_notes](./unreleased_notes/) folder with the
+issue number and an appropriate suffix chosen from the list of `directory` values under each `tool.towncrier.type`
+heading in `pyproject.toml`. For example, the file `unreleased_notes/37.feature` would indicate a note for a feature
+related to issue number #37.
+
+The valid filename extensions are currently:
+
+* .breaking
+* .deprecation
+* .feature
+* .bugfix
+* .refactor
+* .doc
+* .build
+
+See the [towncrier docs](https://towncrier.readthedocs.io/en/stable/index.html) for more details.
+
+## TODO: Rewrite the below info
+
 Setting Up for Local Development
 ********************************
 

--- a/ReleaseNotes.rst
+++ b/ReleaseNotes.rst
@@ -1,8 +1,3 @@
-For newer versions of the package >= 0.15.0, please refer to the GitHub Releases for the changelogs:
-https://github.com/stretch4x4/marshmallow-jsonschema/releases
-
-For older versions of the package < 0.15.0, please see below:
-
 0.14.0 (2025-09-18)
     - First release of the new fork at stretch4x4/marshmallow-jsonschema #9
     - Restricted marshmallow support to 3.x series, due to test failures #2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "marshmallow-jsonschema"
-version = "0.15.0.dev0"
+version = "0.15.1.dev0"
 description = "Formatting marshmallow schemas as JSON Schema Draft v7 (http://json-schema.org/)"
 readme = "README.md"
 license = "MIT"
@@ -54,7 +54,7 @@ Homepage = "https://github.com/stretch4x4/marshmallow-jsonschema"
 Documentation = "https://github.com/stretch4x4/marshmallow-jsonschema/blob/master/README.md"
 Repository = "https://github.com/stretch4x4/marshmallow-jsonschema.git"
 Issues = "https://github.com/stretch4x4/marshmallow-jsonschema/issues"
-Changelog = "https://github.com/stretch4x4/marshmallow-jsonschema/blob/master/CHANGES"
+Changelog = "https://github.com/stretch4x4/marshmallow-jsonschema/blob/master/ReleaseNotes.rst"
 
 [dependency-groups]
 dev = [
@@ -110,3 +110,67 @@ ignore = [
     "S104",  # Possible binding to all interfaces
     "E501", # Line too long
 ]
+
+[tool.towncrier]
+directory = "unreleased_notes"
+filename = "ReleaseNotes.rst"
+title_format = "v{version} - {project_date}"
+issue_format = "`{issue} <https://github.com/stretch4x4/marshmallow-jsonschema/issues/{issue}>`_"
+
+[[tool.towncrier.type]]
+directory = "breaking"
+name = "Incompatible Changes"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "deprecation"
+name = "Deprecations"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "feature"
+name = "Features"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "bugfix"
+name = "Bugfixes"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "refactor"
+name = "Refactoring"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "doc"
+name = "Improved Documentation"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "build"
+name = "Build and Packaging"
+showcontent = true
+
+[tool.bumpversion]
+current_version = "0.15.1.dev0"
+commit = false
+tag = false
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(\\.(?P<release>dev)(?P<dev>\\d+))?"
+serialize = [
+    "{major}.{minor}.{patch}.{release}{dev}",
+    "{major}.{minor}.{patch}",
+]
+pre_commit_hooks = [
+    "uv lock",
+    "git add uv.lock",
+] # this is a bump-my-version invocation unrelated to the pre-commit tool
+
+[tool.bumpversion.parts.release]
+optional_value = "release"
+values = ["dev", "release"]
+
+[[tool.bumpversion.files]]
+filename = "pyproject.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,10 +161,6 @@ serialize = [
     "{major}.{minor}.{patch}.{release}{dev}",
     "{major}.{minor}.{patch}",
 ]
-pre_commit_hooks = [
-    "uv lock",
-    "git add uv.lock",
-] # this is a bump-my-version invocation unrelated to the pre-commit tool
 
 [tool.bumpversion.parts.release]
 optional_value = "release"

--- a/unreleased_notes/.gitkeep
+++ b/unreleased_notes/.gitkeep
@@ -1,0 +1,1 @@
+This file is so that git will always track the unreleased_notes directory (as it may become empty otherwise and ignored)

--- a/unreleased_notes/37.build
+++ b/unreleased_notes/37.build
@@ -1,0 +1,1 @@
+Added support for bump-my-version and towncrier to the release pipeline to enable a fully automated deployment.

--- a/unreleased_notes/37.doc
+++ b/unreleased_notes/37.doc
@@ -1,0 +1,3 @@
+Adopted [towncrier](https://github.com/twisted/towncrier) for managing release notes.
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for more details.


### PR DESCRIPTION
Closes #37.

Just gotta give it a few test runs on my fork to find any bugs but fingers crossed this should do the trick!

Adds `bump-my-version` to manage version bumping and `towncrier` to manage release notes.

The release workflow is now manually triggered and handles everything from start to finish.