### PR TITLE
Use new ruff-check hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,11 +8,8 @@ repos:
 - repo: https://github.com/charliermarsh/ruff-pre-commit
   rev: v0.13.1
   hooks:
-  - id: ruff
-    args:
-    - --fix
-    - --show-fixes
-    - --exit-non-zero-on-fix
+  - id: ruff-check
+    args: [--fix, --show-fixes, --exit-non-zero-on-fix]
   - id: ruff-format
     name: ruff-format
     description: Run 'ruff format' for extremely fast Python formatting


### PR DESCRIPTION
Closes #43 

hook run now doesn't mention legacy alias

```Check Yaml...............................................................Passed
Fix End of Files.........................................................Passed
Trim Trailing Whitespace.................................................Passed
ruff check...............................................................Passed
ruff-format..............................................................Failed
```