### PR TITLE
Refactor release notes to suit new release process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ The valid filename extensions are currently:
 * .refactor
 * .doc
 * .build
+* .contrib
 
 See the [towncrier docs](https://towncrier.readthedocs.io/en/stable/index.html) for more details.
 
@@ -53,11 +54,3 @@ Running tests
 To run all tests: ::
 
     $ pytest
-
-To run syntax checks: ::
-
-    $ tox -e lint
-
-(Optional) To run tests in all supported Python versions in their own virtual environments (must have each interpreter installed): ::
-
-    $ tox

--- a/ReleaseNotes.rst
+++ b/ReleaseNotes.rst
@@ -1,3 +1,12 @@
+0.15.0 (2025-09-22)
+    - Rename to have unique workflow names by @kyluca in #26
+    - run python 3.12 in the build, formatting tweaks - replace #13 by @stretch4x4 in #23
+    - Potential fix for code scanning alert no. 1: Flask app is run in debug mode by @stretch4x4 in #30
+    - Upgrade builds and actions to uv by @stretch4x4 in #32
+    - Add pre-commit hooks by @stretch4x4 in #35
+    - Update build badges by @stretch4x4 in #34
+    - Add basic release workflow by @kyluca in #29
+    - Converting linting and code formatting to ruff by @stretch4x4 in #36
 0.14.0 (2025-09-18)
     - First release of the new fork at stretch4x4/marshmallow-jsonschema #9
     - Restricted marshmallow support to 3.x series, due to test failures #2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,11 @@ directory = "build"
 name = "Build and Packaging"
 showcontent = true
 
+[[tool.towncrier.type]]
+directory = "contrib"
+name = "New Contributors"
+showcontent = true
+
 [tool.bumpversion]
 current_version = "0.15.1.dev0"
 commit = false

--- a/unreleased_notes/10.feature
+++ b/unreleased_notes/10.feature
@@ -1,0 +1,1 @@
+Add Support for marshmallow.fields.Enum in marshmallow ≥ v3.18

--- a/unreleased_notes/14.feature
+++ b/unreleased_notes/14.feature
@@ -1,0 +1,1 @@
+Add support for marshmallow_dataclass union fields by @caldbarksy

--- a/unreleased_notes/15.bugfix
+++ b/unreleased_notes/15.bugfix
@@ -1,0 +1,1 @@
+Fix oneOf validation handling by @jgroth

--- a/unreleased_notes/17.bugfix
+++ b/unreleased_notes/17.bugfix
@@ -1,0 +1,1 @@
+Add ContainsOnly validation support via anyOf by @jgroth

--- a/unreleased_notes/37.build
+++ b/unreleased_notes/37.build
@@ -1,1 +1,1 @@
-Added support for bump-my-version and towncrier to the release pipeline to enable a fully automated deployment.
+Added support for bump-my-version and towncrier to the release pipeline to enable a fully automated deployment. by @kyluca

--- a/unreleased_notes/37.doc
+++ b/unreleased_notes/37.doc
@@ -1,3 +1,3 @@
 Adopted [towncrier](https://github.com/twisted/towncrier) for managing release notes.
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for more details.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for more details. by @kyluca

--- a/unreleased_notes/43.build
+++ b/unreleased_notes/43.build
@@ -1,0 +1,1 @@
+Use new ruff-check hook by @stretch4x4

--- a/unreleased_notes/new_contributors.contrib
+++ b/unreleased_notes/new_contributors.contrib
@@ -1,0 +1,3 @@
+* @winddon made their first contribution in https://github.com/stretch4x4/marshmallow-jsonschema/pull/21
+* @caldbarksy made their first contribution in https://github.com/stretch4x4/marshmallow-jsonschema/pull/20
+* @stockycode made their first contribution in https://github.com/stretch4x4/marshmallow-jsonschema/pull/25


### PR DESCRIPTION
Adding release notes from previous release now we have an automated process
Adding unreleased notes for the already merged items