### PR TITLE
Fix enum oneof conflict

### DIFF
--- a/marshmallow_jsonschema/validation.py
+++ b/marshmallow_jsonschema/validation.py
@@ -85,6 +85,8 @@ def handle_one_of(schema, field, validator, _parent_schema):
         for choice, label in zip(choices, labels, strict=False)
     ]
 
+    schema.pop("enum", None)  # enum and oneOf conflict, so remove enum
+
     return schema
 
 

--- a/unreleased_notes/46.bugfix
+++ b/unreleased_notes/46.bugfix
@@ -1,0 +1,1 @@
+Fix bug with enum / oneOf validation leading to invalid schemas


### PR DESCRIPTION
Addresses #46 

Make the assumption that the validation is more accurate so when putting it in, remove any enum that was present.